### PR TITLE
Adding blurhash option to fm parameter

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "imgix-url-params",
-  "version": "11.11.1",
+  "version": "11.11.2",
   "homepage": "https://github.com/imgix/imgix-url-params",
   "authors": [
     "Jason Eberle <jason@imgix.com>"

--- a/dist/parameters.js
+++ b/dist/parameters.js
@@ -15,7 +15,7 @@
 }(this, function () {
 
 return {
-	"version": "11.11.1",
+	"version": "11.11.2",
 	"parameters": {
 		"ar": {
 			"display_name": "aspect ratio",
@@ -1255,7 +1255,8 @@ return {
 						"png8",
 						"png32",
 						"webp",
-						"webm"
+						"webm",
+						"blurhash"
 					]
 				}
 			],

--- a/dist/parameters.json
+++ b/dist/parameters.json
@@ -1,5 +1,5 @@
 {
-	"version": "11.11.1",
+	"version": "11.11.2",
 	"parameters": {
 		"ar": {
 			"display_name": "aspect ratio",
@@ -1239,7 +1239,8 @@
 						"png8",
 						"png32",
 						"webp",
-						"webm"
+						"webm",
+						"blurhash"
 					]
 				}
 			],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "imgix-url-params",
-  "version": "11.11.1",
+  "version": "11.11.2",
   "description": "Organized, machine-friendly documentation of imgix's URL parameters",
   "main": "dist/manifest.json",
   "scripts": {


### PR DESCRIPTION
Making sure the `blurhash` option for the `fm` parameter gets propagated